### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Mantis MCP Server 是一個基於 Model Context Protocol (MCP) 的服務，用於與 Mantis Bug Tracker 系統進行集成。它提供了一系列工具，允許用戶通過 MCP 協議查詢和分析 Mantis 系統中的數據。
 
+<a href="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server/badge" alt="Mantis Server MCP server" />
+</a>
+
 ## 功能
 
 - 問題管理


### PR DESCRIPTION
This PR adds a badge for the [Mantis MCP Server](https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server/badge" alt="Mantis Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.