### PR TITLE
Add sort/dir support and change_issue_status tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,39 @@
-# 更新日誌
+# Changelog
 
 ## [0.4.0] - 2024-03-29
 
-### 改進
-- 重構代碼，提取重複的 Mantis API 配置檢查邏輯到 `withMantisConfigured` 高階函數
-- 優化錯誤處理，增加更清晰的錯誤標識和響應格式
-- 增強日誌記錄，提供更詳細的錯誤上下文信息
-- 優化 JSON 資料壓縮功能，根據資料大小自動判斷是否需要壓縮
+### Improvements
+- Refactored code, extracting duplicate Mantis API configuration check logic into the `withMantisConfigured` higher-order function
+- Optimized error handling with clearer error identification and response format
+- Enhanced logging with more detailed error context information
+- Optimized JSON data compression functionality, automatically determining compression based on data size
 
-### 重構
-- 統一所有工具的實現方式，減少代碼重複
-- 改進函數型別定義，使代碼更加類型安全
-- 優化錯誤處理流程，提高代碼的可維護性
+### Refactoring
+- Unified implementation approach for all tools, reducing code duplication
+- Improved function type definitions for better type safety
+- Optimized error handling flow, improving code maintainability
 
 ## [0.2.0] - 2024-03-21
 
-### 新增
-- 添加 `withMantisConfigured` 高階函數來處理共用的檢查邏輯
-- 添加結構化的錯誤響應格式，包含 `isError` 標記
+### New Features
+- Added `withMantisConfigured` higher-order function to handle common validation logic
+- Added structured error response format including `isError` flag
 
-### 改進
-- 優化所有工具的回傳型別以符合 MCP SDK 要求
-- 改進錯誤處理機制，提供更詳細的錯誤信息
-- 優化 `get_issues` 工具的壓縮功能
-- 統一化所有工具的錯誤處理和日誌記錄
+### Improvements
+- Optimized return types for all tools to comply with MCP SDK requirements
+- Improved error handling mechanism with more detailed error information
+- Optimized compression functionality for the `get_issues` tool
+- Unified error handling and logging across all tools
 
-### 修復
-- 修正工具回傳型別不符合 MCP SDK 要求的問題
-- 修正錯誤響應格式不一致的問題
+### Bug Fixes
+- Fixed issue where tool return types did not comply with MCP SDK requirements
+- Fixed inconsistent error response format
 
 ## [0.1.0] - 2024-03-20
 
-### 新增
-- 初始版本發布
-- 實現基本的 Mantis API 集成
-- 添加問題管理、用戶管理、專案管理等基本功能
-- 實現統計分析功能
-- 添加效能優化功能（欄位選擇、分頁處理、自動壓縮） 
+### New Features
+- Initial release
+- Implemented basic Mantis API integration
+- Added basic functionality for issue management, user management, and project management
+- Implemented statistical analysis features
+- Added performance optimization features (field selection, pagination, auto-compression) 

--- a/README.md
+++ b/README.md
@@ -2,32 +2,32 @@
 
 [![smithery badge](https://smithery.ai/badge/@kfnzero/mantis-mcp-server)](https://smithery.ai/server/@kfnzero/mantis-mcp-server)
 
-Mantis MCP Server 是一個基於 Model Context Protocol (MCP) 的服務，用於與 Mantis Bug Tracker 系統進行集成。它提供了一系列工具，允許用戶通過 MCP 協議查詢和分析 Mantis 系統中的數據。
+Mantis MCP Server is a service based on the Model Context Protocol (MCP) for integrating with the Mantis Bug Tracker system. It provides a suite of tools that allow users to query and analyze data in the Mantis system through the MCP protocol.
 
 <a href="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@kfnzero/mantis-mcp-server/badge" alt="Mantis Server MCP server" />
 </a>
 
-## 功能
+## Features
 
-- 問題管理
-  - 獲取問題列表（支持多種過濾條件）
-  - 根據 ID 查詢問題詳情
-- 用戶管理
-  - 根據用戶名稱查詢用戶
-  - 獲取所有用戶列表
-- 專案管理
-  - 獲取專案列表
-- 統計分析
-  - 問題統計（支持多維度分析）
-  - 分派統計（分析問題分派情況）
-- 效能優化
-  - 欄位選擇（減少回傳資料量）
-  - 分頁處理（控制每次返回數量）
-  - 自動資料壓縮（大量資料時自動壓縮）
-- 完整的錯誤處理和日誌記錄
+- Issue Management
+  - Get issue list (supports multiple filter conditions)
+  - Query issue details by ID
+- User Management
+  - Query users by username
+  - Get all users list
+- Project Management
+  - Get project list
+- Statistics and Analysis
+  - Issue statistics (supports multi-dimensional analysis)
+  - Assignment statistics (analyze issue assignment status)
+- Performance Optimization
+  - Field selection (reduce returned data volume)
+  - Pagination handling (control returned quantity per request)
+  - Automatic data compression (auto-compress for large datasets)
+- Complete error handling and logging
 
-## 安裝
+## Installation
 
 ### Installing via Smithery
 
@@ -42,50 +42,50 @@ npx -y @smithery/cli install @kfnzero/mantis-mcp-server --client claude
 npm install mantis-mcp-server
 ```
 
-## 配置
+## Configuration
 
-1. 在專案根目錄建立 `.env` 文件：
+1. Create a `.env` file in the project root directory:
 
 ```bash
-# Mantis API 配置
+# Mantis API Configuration
 MANTIS_API_URL=https://your-mantis-instance.com/api/rest
 MANTIS_API_KEY=your_api_key_here
 
-# 應用配置
+# Application Configuration
 NODE_ENV=development  # development, production, test
 LOG_LEVEL=info       # error, warn, info, debug
 
-# 快取配置
+# Cache Configuration
 CACHE_ENABLED=true
-CACHE_TTL_SECONDS=300  # 5分鐘
+CACHE_TTL_SECONDS=300  # 5 minutes
 
-# 日誌配置
+# Logging Configuration
 LOG_DIR=logs
 ENABLE_FILE_LOGGING=false
 ```
 
-### MantisBT API Key 獲取方式
+### How to Obtain MantisBT API Key
 
-1. 登入您的 MantisBT 帳戶
-2. 點擊右上角的用戶名稱，選擇「我的帳戶」
-3. 切換到「API 令牌」標籤
-4. 點擊「創建新令牌」按鈕
-5. 輸入令牌名稱（例如：MCP Server）
-6. 複製生成的 API 令牌，並將其貼入 `.env` 文件的 `MANTIS_API_KEY` 設置中
+1. Log in to your MantisBT account
+2. Click on your username in the top right corner and select "My Account"
+3. Switch to the "API Tokens" tab
+4. Click the "Create New Token" button
+5. Enter a token name (e.g., MCP Server)
+6. Copy the generated API token and paste it into the `MANTIS_API_KEY` setting in the `.env` file
 
-## MCP 配置
+## MCP Configuration
 
-### 全域安裝
+### Global Installation
 
-首先，需要全域安裝 mantis-mcp-server：
+First, you need to install mantis-mcp-server globally:
 
 ```bash
 npm install -g mantis-mcp-server
 ```
 
-### Windows 配置
+### Windows Configuration
 
-在 Windows 系統中，編輯 `%USERPROFILE%\.cursor\mcp.json`（通常在 `C:\Users\你的用戶名\.cursor\mcp.json`），添加以下配置：
+On Windows systems, edit `%USERPROFILE%\.cursor\mcp.json` (typically located at `C:\Users\YourUsername\.cursor\mcp.json`) and add the following configuration:
 
 ```json
 {
@@ -109,9 +109,9 @@ npm install -g mantis-mcp-server
 }
 ```
 
-### macOS/Linux 配置
+### macOS/Linux Configuration
 
-在 macOS 或 Linux 系統中，編輯 `~/.cursor/mcp.json`，添加以下配置：
+On macOS or Linux systems, edit `~/.cursor/mcp.json` and add the following configuration:
 
 ```json
 {
@@ -133,25 +133,25 @@ npm install -g mantis-mcp-server
 }
 ```
 
-> 注意：在 macOS/Linux 中，我們使用 npx 來運行最新版本的 mantis-mcp-server，這樣可以確保始終使用最新版本，不需要全域安裝。
+> Note: On macOS/Linux, we use npx to run the latest version of mantis-mcp-server, ensuring you always use the most recent version without needing a global installation.
 
-### 環境變數說明
+### Environment Variable Descriptions
 
-- `MANTIS_API_URL`: 您的 Mantis API URL
-- `MANTIS_API_KEY`: 您的 Mantis API 金鑰
-- `NODE_ENV`: 執行環境，建議設置為 "production"
-- `LOG_LEVEL`: 日誌級別，可選值：error、warn、info、debug
+- `MANTIS_API_URL`: Your Mantis API URL
+- `MANTIS_API_KEY`: Your Mantis API key
+- `NODE_ENV`: Execution environment, recommended to set to "production"
+- `LOG_LEVEL`: Log level, options: error, warn, info, debug
 
-### 驗證配置
+### Verifying Configuration
 
-配置完成後，您可以：
+After configuration is complete, you can:
 
-1. 重新載入 Cursor MCP
-2. 開啟命令面板（Windows: Ctrl+Shift+P, Mac: Cmd+Shift+P）
+1. Reload Cursor MCP
+2. Open the command palette (Windows: Ctrl+Shift+P, Mac: Cmd+Shift+P)
 
-## 在 Cursor 中設定
+## Setting Up in Cursor
 
-1. 在 `.vscode/mcp.json` 中添加以下配置：
+1. Add the following configuration to `.vscode/mcp.json`:
 
 ```json
 {
@@ -165,7 +165,7 @@ npm install -g mantis-mcp-server
 }
 ```
 
-2. 在 `.vscode/launch.json` 中添加以下配置用於除錯：
+2. Add the following configuration to `.vscode/launch.json` for debugging:
 
 ```json
 {
@@ -197,125 +197,125 @@ npm install -g mantis-mcp-server
 }
 ```
 
-## API 工具說明
+## API Tools Documentation
 
-### 1. 獲取問題列表 (get_issues)
+### 1. Get Issues List (get_issues)
 
-獲取 Mantis 問題列表，可根據多個條件進行過濾。
+Get a list of Mantis issues with support for filtering by multiple conditions.
 
-**參數：**
-- `projectId` (可選): 專案 ID
-- `statusId` (可選): 狀態 ID
-- `handlerId` (可選): 處理人 ID
-- `reporterId` (可選): 報告者 ID
-- `search` (可選): 搜尋關鍵字
-- `pageSize` (可選, 默認 20): 頁數大小
-- `page` (可選, 默認 0): 分頁起始位置，從1開始
-- `select` (可選): 選擇要返回的欄位，例如：['id', 'summary', 'description']。可用於減少回傳資料量
+**Parameters:**
+- `projectId` (optional): Project ID
+- `statusId` (optional): Status ID
+- `handlerId` (optional): Handler ID
+- `reporterId` (optional): Reporter ID
+- `search` (optional): Search keyword
+- `pageSize` (optional, default 20): Page size
+- `page` (optional, default 0): Page number, starting from 1
+- `select` (optional): Select fields to return, e.g., ['id', 'summary', 'description']. Can be used to reduce returned data volume
 
-### 2. 獲取問題詳情 (get_issue_by_id)
+### 2. Get Issue Details (get_issue_by_id)
 
-根據 ID 獲取 Mantis 問題詳情。
+Get Mantis issue details by ID.
 
-**參數：**
-- `issueId`: 問題 ID
+**Parameters:**
+- `issueId`: Issue ID
 
-### 3. 查詢用戶 (get_user)
+### 3. Query User (get_user)
 
-根據用戶名稱查詢 Mantis 用戶。
+Query Mantis users by username.
 
-**參數：**
-- `username`: 用戶名稱
+**Parameters:**
+- `username`: Username
 
-### 4. 獲取專案列表 (get_projects)
+### 4. Get Projects List (get_projects)
 
-獲取 Mantis 專案列表。
+Get a list of Mantis projects.
 
-**參數：** 無
+**Parameters:** None
 
-### 5. 獲取問題統計 (get_issue_statistics)
+### 5. Get Issue Statistics (get_issue_statistics)
 
-獲取 Mantis 問題統計數據，根據不同維度進行分析。
+Get Mantis issue statistics, analyzed by different dimensions.
 
-**參數：**
-- `projectId` (可選): 專案 ID
-- `groupBy`: 分組依據，可選值: 'status', 'priority', 'severity', 'handler', 'reporter'
-- `period` (默認 'all'): 時間範圍，可選值: 'all', 'today', 'week', 'month'
+**Parameters:**
+- `projectId` (optional): Project ID
+- `groupBy`: Group by field, options: 'status', 'priority', 'severity', 'handler', 'reporter'
+- `period` (default 'all'): Time range, options: 'all', 'today', 'week', 'month'
 
-### 6. 獲取分派統計 (get_assignment_statistics)
+### 6. Get Assignment Statistics (get_assignment_statistics)
 
-獲取 Mantis 問題分派統計數據，分析不同用戶的問題分派情況。
+Get Mantis issue assignment statistics, analyzing issue distribution across users.
 
-**參數：**
-- `projectId` (可選): 專案 ID
-- `includeUnassigned` (默認 true): 是否包含未分派問題
-- `statusFilter` (可選): 狀態過濾器，只計算特定狀態的問題
+**Parameters:**
+- `projectId` (optional): Project ID
+- `includeUnassigned` (default true): Whether to include unassigned issues
+- `statusFilter` (optional): Status filter, only count issues with specific statuses
 
-### 7. 獲取所有用戶 (get_users)
+### 7. Get All Users (get_users)
 
-用暴力法獲取所有用戶列表。
+Get all users list using a brute force method.
 
-**參數：** 無
+**Parameters:** None
 
-## 代碼結構
+## Code Structure
 
-### 高階函數
-服務使用 `withMantisConfigured` 高階函數來處理共用的檢查邏輯，確保：
-- Mantis API 配置檢查
-- 統一的錯誤處理
-- 標準化的回應格式
-- 自動的日誌記錄
+### Higher-Order Functions
+The service uses the `withMantisConfigured` higher-order function to handle common validation logic, ensuring:
+- Mantis API configuration validation
+- Unified error handling
+- Standardized response format
+- Automatic logging
 
-### 錯誤處理
-完整的錯誤處理機制包括：
-- Mantis API 錯誤處理（包含 HTTP 狀態碼）
-- 通用錯誤處理
-- 結構化的錯誤響應
-- 詳細的錯誤日誌
+### Error Handling
+Comprehensive error handling mechanism includes:
+- Mantis API error handling (including HTTP status codes)
+- General error handling
+- Structured error responses
+- Detailed error logging
 
-## 開發
+## Development
 
 ```bash
-# 安裝依賴
+# Install dependencies
 npm install
 
-# 構建
+# Build
 npm run build
 
-# 開發模式（監視變更）
+# Development mode (watch for changes)
 npm run watch
 
-# 運行
+# Run
 npm start
 ```
 
-## 日誌
+## Logging
 
-如果啟用了檔案日誌（`ENABLE_FILE_LOGGING=true`），日誌文件將保存在：
+If file logging is enabled (`ENABLE_FILE_LOGGING=true`), log files will be saved to:
 
-- `logs/mantis-mcp-server-combined.log`: 所有級別的日誌
-- `logs/mantis-mcp-server-error.log`: 僅錯誤級別的日誌
+- `logs/mantis-mcp-server-combined.log`: Logs of all levels
+- `logs/mantis-mcp-server-error.log`: Error level logs only
 
-日誌文件大小上限為 5MB，最多保留 5 個歷史文件。
+Log files have a maximum size of 5MB and keep up to 5 historical files.
 
-## 許可證
+## License
 
 MIT
 
-## 參考
+## References
 
 @https://documenter.getpostman.com/view/29959/7Lt6zkP#c0c24256-341e-4649-95cb-ad7bdc179399 
 
 
-# 發布
+# Publishing
 npm login --registry=https://registry.npmjs.org/
 npm run build
 npm publish --access public --registry=https://registry.npmjs.org/
 
-# 更新版本號
-npm version patch  # 修復版本 0.0.x
-npm version minor  # 次要版本 0.x.0
-npm version major  # 主要版本 x.0.0
+# Update version number
+npm version patch  # Patch version 0.0.x
+npm version minor  # Minor version 0.x.0
+npm version major  # Major version x.0.0
 
-# 重新發布
+# Republish
 npm publish

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,39 +1,39 @@
-# 當前上下文
+# Active Context
 
-## 當前重點
-- 添加單元測試和整合測試
-- 準備發布第一個版本
-- 優化錯誤處理
+## Current Focus
+- Add unit tests and integration tests
+- Prepare to release first version
+- Optimize error handling
 
-## 最近更改
-- 完成 Mantis API 整合
-- 實現基本錯誤處理機制
-- 添加環境變數配置
-- 優化工具實現
-- 添加緩存機制
-- 完成統計功能實現
-- 更新 README 文檔和使用指南
+## Recent Changes
+- Completed Mantis API integration
+- Implemented basic error handling mechanism
+- Added environment variable configuration
+- Optimized tool implementation
+- Added caching mechanism
+- Completed statistics functionality implementation
+- Updated README documentation and user guide
 
-## 待處理事項
-- 添加單元測試
-- 添加整合測試
-- 添加更多的錯誤處理和邊緣情況
-- 優化緩存機制
+## Pending Items
+- Add unit tests
+- Add integration tests
+- Add more error handling and edge cases
+- Optimize caching mechanism
 
-## 架構決策
-- 基於 MCP SDK 開發的 MCP Server
-- 利用 TypeScript 和 Zod 進行類型驗證和參數處理
-- 使用 Axios 進行 Mantis API 調用
-- 實作模組化設計，便於功能擴展
-- 添加環境變數和配置管理
-- 實作緩存機制提高性能
-- 實現統計功能支持多種維度分析
+## Architectural Decisions
+- MCP Server developed based on MCP SDK
+- Use TypeScript and Zod for type validation and parameter processing
+- Use Axios for Mantis API calls
+- Implement modular design for easy feature expansion
+- Add environment variables and configuration management
+- Implement caching mechanism to improve performance
+- Implement statistics functionality supporting multi-dimensional analysis
 
-## 最近完成
-- 完成基礎架構建設
-- 完成 Mantis API 整合
-- 實現 6 個核心工具功能
-- 添加認證機制
-- 實現錯誤處理和緩存
-- 實現統計功能
-- 完成文檔撰寫 
+## Recently Completed
+- Completed infrastructure construction
+- Completed Mantis API integration
+- Implemented 6 core tool functionalities
+- Added authentication mechanism
+- Implemented error handling and caching
+- Implemented statistics functionality
+- Completed documentation writing 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,24 +1,24 @@
-# 產品上下文
+# Product Context
 
-## 專案目的
-MCP Server旨在簡化Mantis缺陷追蹤系統的使用流程，通過提供專門的API接口，使團隊能夠更有效地獲取和分析問題數據。這將幫助團隊更好地理解專案狀態，優化工作分配，並提高整體開發效率。
+## Project Purpose
+The MCP Server aims to simplify the workflow of the Mantis defect tracking system by providing specialized API interfaces, enabling teams to more effectively retrieve and analyze issue data. This will help teams better understand project status, optimize work allocation, and improve overall development efficiency.
 
-## 目標用戶
-- 開發團隊負責人和管理者
-- 專案經理和產品所有者
-- 開發人員和測試人員
-- DevOps團隊成員
+## Target Users
+- Development team leaders and managers
+- Project managers and product owners
+- Developers and testers
+- DevOps team members
 
-## 主要功能
-- Mantis API整合與認證
-- 問題狀態查詢與統計
-- 問題分派情況查詢與統計
-- 資料分析與報表功能
-- API接口提供
+## Main Features
+- Mantis API integration and authentication
+- Issue status query and statistics
+- Issue assignment query and statistics
+- Data analysis and reporting functionality
+- API interface provision
 
-## 預期效益
-- 提高專案狀態的可見性和透明度
-- 減少手動檢查和統計的時間
-- 優化資源分配和工作分派
-- 提供數據支持以改進開發流程
-- 增強團隊協作效率 
+## Expected Benefits
+- Improve project status visibility and transparency
+- Reduce time spent on manual checking and statistics
+- Optimize resource allocation and work assignment
+- Provide data support to improve development processes
+- Enhance team collaboration efficiency 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,45 +1,45 @@
-# 進度追蹤
+# Progress Tracking
 
-## 當前進度
-- 完成 MCP Server 核心功能實現
-- 完成 Mantis API 整合
-- 完成統計功能開發
-- 進行中: 測試和優化
+## Current Progress
+- Completed MCP Server core functionality implementation
+- Completed Mantis API integration
+- Completed statistics functionality development
+- In Progress: Testing and optimization
 
-## 里程碑
-- [X] 完成基本專案設置
-- [X] 完成系統架構設計
-- [X] 建立基礎伺服器架構
-- [X] 實作 Mantis API 連接
-- [X] 實作認證機制
-- [X] 完成問題狀態查詢功能
-- [X] 完成問題分派查詢功能
-- [X] 實作統計功能
-- [ ] 完成測試和文檔
+## Milestones
+- [X] Complete basic project setup
+- [X] Complete system architecture design
+- [X] Establish basic server architecture
+- [X] Implement Mantis API connection
+- [X] Implement authentication mechanism
+- [X] Complete issue status query functionality
+- [X] Complete issue assignment query functionality
+- [X] Implement statistics functionality
+- [ ] Complete testing and documentation
 
-## 已完成的任務
-- 初始化專案結構和文件
-- 定義 MCP Server 的核心需求
-- 設計系統架構和選擇技術堆疊
-- 確定以 MCP SDK 作為基礎開發
-- 實作環境變數配置
-- 實作 Mantis API 客戶端
-- 添加 API 認證機制
-- 實作錯誤處理機制
-- 實作 6 個核心工具功能
-- 實作請求緩存機制
-- 實作問題統計和分派統計功能
-- 更新使用文檔
+## Completed Tasks
+- Initialize project structure and files
+- Define MCP Server core requirements
+- Design system architecture and select technology stack
+- Decide to develop based on MCP SDK
+- Implement environment variable configuration
+- Implement Mantis API client
+- Add API authentication mechanism
+- Implement error handling mechanism
+- Implement 6 core tool functionalities
+- Implement request caching mechanism
+- Implement issue statistics and assignment statistics functionality
+- Update usage documentation
 
-## 遇到的挑戰
-- TypeScript 中 Zod 與 MCP SDK 整合的類型定義
-- 模組路徑引用需要添加 .js 後綴
-- 錯誤處理需要考慮多種情況
-- 緩存機制需要平衡實時性和性能
-- 統計功能需要處理大量數據和不同維度
+## Challenges Encountered
+- Type definitions for Zod integration with MCP SDK in TypeScript
+- Module path references need to add .js suffix
+- Error handling needs to consider multiple scenarios
+- Caching mechanism needs to balance real-time performance and efficiency
+- Statistics functionality needs to handle large amounts of data and different dimensions
 
-## 下一步計劃
-- 添加單元測試和整合測試
-- 優化錯誤處理和邊緣情況
-- 優化緩存機制
-- 完善文檔和使用示例 
+## Next Steps
+- Add unit tests and integration tests
+- Optimize error handling and edge cases
+- Optimize caching mechanism
+- Improve documentation and usage examples 

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,25 +1,25 @@
-# 專案簡介
+# Project Brief
 
-## 目標
-開發一個MCP Server，用於串接Mantis工具，提供查詢和統計功能，並支援認證機制。
+## Goal
+Develop an MCP Server to integrate with Mantis tools, providing query and statistics features with authentication support.
 
-## 主要需求
-- 連接Mantis API並進行整合
-- 支援使用Mantis位置與API Key進行認證
-- 依據問題狀態進行查詢和統計
-- 依據被分派的人員進行查詢和統計
-- 提供簡潔易用的API接口
+## Main Requirements
+- Connect to and integrate with Mantis API
+- Support authentication using Mantis location and API Key
+- Query and statistics based on issue status
+- Query and statistics based on assigned personnel
+- Provide a simple and easy-to-use API interface
 
-## 技術要求
-- 伺服器架構設計
-- API整合與認證實作
-- 資料查詢與統計功能
-- 安全機制實作
-- 錯誤處理與日誌
+## Technical Requirements
+- Server architecture design
+- API integration and authentication implementation
+- Data query and statistics functionality
+- Security mechanism implementation
+- Error handling and logging
 
-## 成功標準
-- 成功連接Mantis API並通過認證
-- 正確查詢和統計問題狀態資訊
-- 正確查詢和統計問題分派資訊
-- 系統穩定運行
-- 響應時間符合要求 
+## Success Criteria
+- Successfully connect to Mantis API and pass authentication
+- Correctly query and generate statistics for issue status information
+- Correctly query and generate statistics for issue assignment information
+- System runs stably
+- Response time meets requirements 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,27 +1,27 @@
-# 系統模式
+# System Patterns
 
-## 架構決策
-- 採用RESTful API設計，提供清晰的接口
-- 實作MVC架構分離關注點
-- 使用模組化設計，便於維護和擴展
-- 採用中間件處理認證和日誌
-- 實作緩存機制提高性能
+## Architectural Decisions
+- Adopt RESTful API design for clear interfaces
+- Implement MVC architecture to separate concerns
+- Use modular design for easy maintenance and expansion
+- Use middleware to handle authentication and logging
+- Implement caching mechanism to improve performance
 
-## 設計模式
-- 單例模式: 用於數據庫連接和配置管理
-- 工廠模式: 用於創建Mantis API客戶端
-- 裝飾器模式: 用於API驗證和日誌記錄
-- 策略模式: 用於不同統計算法的實現
-- 觀察者模式: 用於系統事件通知
+## Design Patterns
+- Singleton Pattern: For database connections and configuration management
+- Factory Pattern: For creating Mantis API clients
+- Decorator Pattern: For API validation and logging
+- Strategy Pattern: For implementing different statistical algorithms
+- Observer Pattern: For system event notifications
 
-## 技術債務
-- 需要在後期新增更多的統計與分析功能
-- 可能需要優化大量數據查詢的性能
-- 初期版本缺少完整的單元測試覆蓋
+## Technical Debt
+- Need to add more statistics and analysis features in later stages
+- May need to optimize performance for large data queries
+- Initial version lacks complete unit test coverage
 
-## 最佳實踐
-- 全面的錯誤處理和日誌記錄
-- 使用環境變數進行配置管理
-- 實作API版本控制
-- 定期進行安全更新
-- 確保代碼遵循SOLID原則 
+## Best Practices
+- Comprehensive error handling and logging
+- Use environment variables for configuration management
+- Implement API versioning
+- Perform regular security updates
+- Ensure code follows SOLID principles 

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -1,53 +1,53 @@
-# 任務追蹤
+# Task Tracking
 
-## 進行中的任務
-- [X] 初始化專案結構和文件
-- [X] 擴展 MCP Server 功能
-  - [X] 修改 get_issues 工具與 Mantis API 整合
-  - [X] 實作認證機制
-  - [X] 實作問題查詢功能
-  - [X] 實作分派查詢功能
-  - [X] 實作統計功能
+## Tasks in Progress
+- [X] Initialize project structure and files
+- [X] Expand MCP Server functionality
+  - [X] Modify get_issues tool to integrate with Mantis API
+  - [X] Implement authentication mechanism
+  - [X] Implement issue query functionality
+  - [X] Implement assignment query functionality
+  - [X] Implement statistics functionality
 
-## MCP Server 開發計劃
-### 基礎架構完善
-- [X] 修改現有的 get_issues 工具
-- [X] 添加必要的工具類和輔助函數
-- [X] 實作基本的錯誤處理機制
-- [X] 添加環境變數配置 (dotenv)
+## MCP Server Development Plan
+### Infrastructure Improvement
+- [X] Modify existing get_issues tool
+- [X] Add necessary utility classes and helper functions
+- [X] Implement basic error handling mechanism
+- [X] Add environment variable configuration (dotenv)
 
-### Mantis API 整合
-- [X] 添加 Axios 依賴
-- [X] 建立 API 客戶端類別
-- [X] 實作 Mantis 連接配置
-- [X] 實作基本的 API 調用功能
-- [X] 實作錯誤處理與重試機制
-- [X] 實作請求節流和緩存功能
+### Mantis API Integration
+- [X] Add Axios dependency
+- [X] Create API client class
+- [X] Implement Mantis connection configuration
+- [X] Implement basic API call functionality
+- [X] Implement error handling and retry mechanism
+- [X] Implement request throttling and caching functionality
 
-### 工具功能擴展
-- [X] 修改 get_issues 工具實現真實查詢
-- [X] 添加 get_issue_by_id 工具
-- [X] 添加 get_users 工具
-- [X] 添加 get_projects 工具
-- [X] 添加 get_issue_statistics 工具
-- [X] 添加 get_assignment_statistics 工具
+### Tool Functionality Expansion
+- [X] Modify get_issues tool to implement real queries
+- [X] Add get_issue_by_id tool
+- [X] Add get_users tool
+- [X] Add get_projects tool
+- [X] Add get_issue_statistics tool
+- [X] Add get_assignment_statistics tool
 
-### 認證機制
-- [X] 添加認證配置模型
-- [X] 實作 API Key 驗證
-- [X] 設計 Mantis 整合認證
-- [X] 添加認證錯誤處理
+### Authentication Mechanism
+- [X] Add authentication configuration model
+- [X] Implement API Key validation
+- [X] Design Mantis integration authentication
+- [X] Add authentication error handling
 
-### 測試與文檔
-- [ ] 添加單元測試
-- [ ] 添加整合測試
-- [X] 更新 README 文檔
-- [X] 添加使用說明文檔
+### Testing and Documentation
+- [ ] Add unit tests
+- [ ] Add integration tests
+- [X] Update README documentation
+- [X] Add usage documentation
 
-## 已完成的任務
-- [X] 初始化專案結構和文件
-- [X] 設計系統架構
-- [X] 實作 Mantis API 整合
-- [X] 實作問題查詢功能
-- [X] 實作認證機制
-- [X] 實作統計功能 
+## Completed Tasks
+- [X] Initialize project structure and files
+- [X] Design system architecture
+- [X] Implement Mantis API integration
+- [X] Implement issue query functionality
+- [X] Implement authentication mechanism
+- [X] Implement statistics functionality 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,31 +1,31 @@
-# 技術上下文
+# Technical Context
 
-## 開發環境
-- 作業系統: Windows
+## Development Environment
+- Operating System: Windows
 - Shell: Git Bash
-- 編輯器: VSCode或其他適合的IDE
+- Editor: VSCode or other suitable IDE
 
-## 技術堆疊
-- 語言: TypeScript
-- 後端框架: Node.js + Express.js
-- 數據庫: MongoDB (用於緩存和日誌)
-- API整合: Axios用於HTTP請求
-- 認證: JWT (JSON Web Tokens)
-- 日誌: Winston
-- 測試: Jest + Supertest
+## Technology Stack
+- Language: TypeScript
+- Backend Framework: Node.js + Express.js
+- Database: MongoDB (for caching and logging)
+- API Integration: Axios for HTTP requests
+- Authentication: JWT (JSON Web Tokens)
+- Logging: Winston
+- Testing: Jest + Supertest
 
-## 開發工具
-- Git: 版本控制
-- Postman: API測試
-- ESLint: 代碼質量
-- Prettier: 代碼格式化
-- Nodemon: 開發熱重載
-- ts-node: TypeScript執行環境
-- Docker: 容器化部署
+## Development Tools
+- Git: Version control
+- Postman: API testing
+- ESLint: Code quality
+- Prettier: Code formatting
+- Nodemon: Development hot reload
+- ts-node: TypeScript execution environment
+- Docker: Containerized deployment
 
-## 部署環境
-- 容器: Docker
+## Deployment Environment
+- Container: Docker
 - CI/CD: GitHub Actions
-- 監控: PM2
-- 雲平台: 根據需要選擇適合的雲服務提供商
-- 環境變數: dotenv管理 
+- Monitoring: PM2
+- Cloud Platform: Choose appropriate cloud service provider as needed
+- Environment Variables: Managed with dotenv 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,28 +6,28 @@ import { createServer } from "./server.js";
 import { log } from "./utils/logger.js";
 
 async function main() {
-  // 輸出環境配置
-  log.info("=== Mantis MCP Server 配置資訊 ===", {
+  // Output environment configuration
+  log.info("=== Mantis MCP Server Configuration ===", {
     api_url: config.MANTIS_API_URL,
     api_configured: isMantisConfigured(),
     environment: config.NODE_ENV,
     log_level: config.LOG_LEVEL,
     cache_enabled: config.CACHE_ENABLED,
     cache_ttl: config.CACHE_TTL_SECONDS,
-    file_logging: config.ENABLE_FILE_LOGGING ? `啟用 (${config.LOG_DIR})` : '停用'
+    file_logging: config.ENABLE_FILE_LOGGING ? `Enabled (${config.LOG_DIR})` : 'Disabled'
   });
 
   if (!isMantisConfigured()) {
-    log.warn("Mantis API 未完整配置,部分功能可能無法使用");
+    log.warn("Mantis API is not fully configured, some features may not be available");
   }
 
   const server: McpServer = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  log.info("Mantis MCP Server 已在 stdio 上啟動");
+  log.info("Mantis MCP Server started on stdio");
 }
 
 main().catch((error) => {
-  log.error("主程序發生致命錯誤", { error: error.message, stack: error.stack });
+  log.error("Fatal error in main program", { error: error.message, stack: error.stack });
   process.exit(1);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -458,10 +458,17 @@ export function createServer(): McpServer {
       priority: z.string().optional().describe("Priority"),
       severity: z.string().optional().describe("Severity"),
       additional_information: z.string().optional().describe("Additional information"),
+      custom_fields: z.array(z.object({
+        field: z.object({
+          id: z.number().optional().describe("Custom field ID"),
+          name: z.string().optional().describe("Custom field name"),
+        }).describe("Custom field identifier (id or name)"),
+        value: z.string().describe("Custom field value"),
+      })).optional().describe("Custom fields to set"),
     },
     async (params) => {
       return withMantisConfigured("create_issue", async () => {
-        const issueData = {
+        const issueData: any = {
           summary: params.summary,
           description: params.description,
           project: { id: params.projectId },
@@ -471,6 +478,9 @@ export function createServer(): McpServer {
           severity: params.severity ? { name: params.severity } : undefined,
           additional_information: params.additional_information,
         };
+        if (params.custom_fields?.length) {
+          issueData.custom_fields = params.custom_fields;
+        }
         const issue = await mantisApi.createIssue(issueData);
         return JSON.stringify(issue, null, 2);
       });
@@ -490,10 +500,17 @@ export function createServer(): McpServer {
       resolution: z.string().optional().describe("Resolution"),
       priority: z.string().optional().describe("Priority"),
       severity: z.string().optional().describe("Severity"),
+      custom_fields: z.array(z.object({
+        field: z.object({
+          id: z.number().optional().describe("Custom field ID"),
+          name: z.string().optional().describe("Custom field name"),
+        }).describe("Custom field identifier (id or name)"),
+        value: z.string().describe("Custom field value"),
+      })).optional().describe("Custom fields to update"),
     },
     async (params) => {
       return withMantisConfigured("update_issue", async () => {
-        const updateData = {
+        const updateData: any = {
           summary: params.summary,
           description: params.description,
           handler: params.handlerId ? { id: params.handlerId } : undefined,
@@ -502,6 +519,9 @@ export function createServer(): McpServer {
           priority: params.priority ? { name: params.priority } : undefined,
           severity: params.severity ? { name: params.severity } : undefined,
         };
+        if (params.custom_fields?.length) {
+          updateData.custom_fields = params.custom_fields;
+        }
         const issue = await mantisApi.updateIssue(params.issueId, updateData);
         return JSON.stringify(issue, null, 2);
       });

--- a/src/services/mantisApi.ts
+++ b/src/services/mantisApi.ts
@@ -111,9 +111,9 @@ export class MantisApi {
         throw error;
       }
       if (error instanceof Error) {
-        throw new MantisApiError(`獲取用戶資訊失敗: ${error.message}`);
+        throw new MantisApiError(`Failed to get user info: ${error.message}`);
       }
-      throw new MantisApiError('獲取用戶資訊失敗');
+      throw new MantisApiError('Failed to get user info');
     }
   }
   private api: AxiosInstance;
@@ -121,8 +121,8 @@ export class MantisApi {
 
   constructor() {
     if (!config.MANTIS_API_URL) {
-      log.error('未設置 Mantis API URL');
-      throw new Error('未設置 Mantis API URL');
+      log.error('Mantis API URL is not set');
+      throw new Error('Mantis API URL is not set');
     }
 
     this.api = axios.create({
@@ -134,18 +134,18 @@ export class MantisApi {
       },
     });
 
-    log.info('已初始化 Mantis API 客戶端', {
+    log.info('Mantis API client initialized', {
       baseURL: config.MANTIS_API_URL,
       timeout: 10000,
       hasApiKey: !!config.MANTIS_API_KEY
     });
 
-    // 添加請求攔截器用於錯誤處理
+    // Add response interceptor for error handling
     this.api.interceptors.response.use(
       (response) => response,
       (error) => {
         if (error.response) {
-          const errorMessage = `API 錯誤: ${error.response.status} ${error.response.statusText}`;
+          const errorMessage = `API error: ${error.response.status} ${error.response.statusText}`;
           log.error(errorMessage, {
             status: error.response.status,
             data: error.response.data,
@@ -157,14 +157,14 @@ export class MantisApi {
             error.response.data
           );
         } else if (error.request) {
-          const errorMessage = '未收到 API 響應';
+          const errorMessage = 'No API response received';
           log.error(errorMessage, {
             url: error.config?.url,
             method: error.config?.method
           });
           throw new MantisApiError(errorMessage, 0);
         } else {
-          const errorMessage = `請求錯誤: ${error.message}`;
+          const errorMessage = `Request error: ${error.message}`;
           log.error(errorMessage, {
             url: error.config?.url,
             error: error.message
@@ -175,7 +175,7 @@ export class MantisApi {
     );
   }
 
-  // 使用緩存包裝 API 調用
+  // Wrap API calls with caching
   private async cachedRequest<T>(
     key: string,
     requestFn: () => Promise<AxiosResponse<T>>
@@ -184,18 +184,18 @@ export class MantisApi {
       const cachedData = this.cache.get(key);
       const now = Date.now();
       
-      // 如果緩存有效並且未過期
+      // If cache is valid and not expired
       if (
         cachedData &&
         now - cachedData.timestamp < config.CACHE_TTL_SECONDS * 1000
       ) {
-        log.debug('使用緩存數據', { key, age: (now - cachedData.timestamp) / 1000 });
+        log.debug('Using cached data', { key, age: (now - cachedData.timestamp) / 1000 });
         return cachedData.data;
       }
     }
     
-    // 沒有緩存或緩存過期，執行請求
-    log.debug('發送 API 請求', { key });
+    // No cache or cache expired, execute request
+    log.debug('Sending API request', { key });
     const response = await requestFn();
     
     if (config.CACHE_ENABLED) {
@@ -203,17 +203,17 @@ export class MantisApi {
         data: response.data,
         timestamp: Date.now(),
       });
-      log.debug('更新緩存數據', { key });
+      log.debug('Cache updated', { key });
     }
     
     return response.data;
   }
 
-  // 獲取問題列表
+  // Get issue list
   async getIssues(params: IssueSearchParams = {}): Promise<Issue[]> {
-    log.info('獲取問題列表', { params });
+    log.info('Fetching issue list', { params });
     
-    // 構建過濾 URL
+    // Build filter URL
     let filter = '';
     if (params.projectId) filter += `&project_id=${params.projectId}`;
     if (params.statusId) filter += `&status_id=${params.statusId}`;
@@ -236,9 +236,9 @@ export class MantisApi {
     return response.issues;
   }
 
-  // 獲取單個問題詳情
+  // Get single issue details
   async getIssueById(issueId: number): Promise<Issue> {
-    log.info('獲取問題詳情', { issueId });
+    log.info('Fetching issue details', { issueId });
     
     const cacheKey = `issue-${issueId}`;
     
@@ -247,9 +247,9 @@ export class MantisApi {
     });
   }
 
-  // 獲取當前用戶信息
+  // Get current user info
   async getCurrentUser(): Promise<User> {
-    log.info('獲取當前用戶信息');
+    log.info('Fetching current user info');
     
     const cacheKey = 'current-user';
     
@@ -258,12 +258,12 @@ export class MantisApi {
     });
   }
 
-  // 獲取指定用戶信息
+  // Get user info by ID
   async getUser(userId: number): Promise<User> {
-    log.info('獲取用戶信息', { userId });
+    log.info('Fetching user info', { userId });
     
     if (!userId) {
-      throw new MantisApiError('必須提供用戶 ID');
+      throw new MantisApiError('User ID is required');
     }
     
     const cacheKey = `user-${userId}`;
@@ -273,9 +273,9 @@ export class MantisApi {
     });
   }
 
-  // 獲取項目列表
+  // Get project list
   async getProjects(): Promise<Project[]> {
-    log.info('獲取項目列表');
+    log.info('Fetching project list');
     
     const cacheKey = 'projects';
     
@@ -284,9 +284,9 @@ export class MantisApi {
     });
   }
 
-  // 獲取指定專案的所有使用者
+  // Get all users for a specific project
   async getUsersByProjectId(projectId: number): Promise<User[]> {
-    log.info('獲取指定專案的所有使用者', { projectId });
+    log.info('Fetching all users for project', { projectId });
     
     const cacheKey = `users-by-project-${projectId}`;
     
@@ -295,38 +295,38 @@ export class MantisApi {
     });
   }
 
-  // 清除緩存
+  // Clear cache
   clearCache() {
-    log.info('清除 API 緩存');
+    log.info('Clearing API cache');
     this.cache.clear();
   }
 
-  // 新增 issue
+  // Create issue
   async createIssue(issueData: any): Promise<Issue> {
-    log.info('新增 Issue', { issueData });
+    log.info('Creating issue', { issueData });
     const response = await this.api.post('/issues', issueData);
-    this.clearCache(); // 清除快取，因為有新的 issue
+    this.clearCache(); // Clear cache because a new issue was created
     return response.data.issue;
   }
 
-  // 修改 issue
+  // Update issue
   async updateIssue(issueId: number, updateData: any): Promise<Issue> {
-    log.info('修改 Issue', { issueId, updateData });
+    log.info('Updating issue', { issueId, updateData });
     const response = await this.api.patch(`/issues/${issueId}`, updateData);
-    this.clearCache(); // 清除快取，因為 issue 已更新
+    this.clearCache(); // Clear cache because issue was updated
     return response.data.issue;
   }
 
-  // 新增 issue note
+  // Add issue note
   async addIssueNote(issueId: number, noteData: any): Promise<any> {
-    log.info('新增 Issue Note', { issueId, noteData });
+    log.info('Adding issue note', { issueId, noteData });
     const response = await this.api.post(`/issues/${issueId}/notes`, noteData);
-    this.clearCache(); // 清除快取，因為 issue 已更新
+    this.clearCache(); // Clear cache because issue was updated
     return response.data;
   }
 }
 
-// 創建單例實例
+// Create singleton instance
 export const mantisApi = new MantisApi();
 
 export default mantisApi; 

--- a/src/services/mantisApi.ts
+++ b/src/services/mantisApi.ts
@@ -36,6 +36,13 @@ export interface Issue {
     id: number;
     name: string;
   };
+  custom_fields?: Array<{
+    field: {
+      id: number;
+      name: string;
+    };
+    value: string;
+  }>;
   created_at: string;
   updated_at: string;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,7 +2,7 @@ import winston from 'winston';
 import path from 'path';
 import { config } from '../config/index.js';
 
-// 定義日誌格式
+// Define log format
 const logFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.json()
@@ -11,24 +11,24 @@ const logLevel = process.env.LOG_LEVEL || 'info';
 const enableFileLogging = process.env.ENABLE_FILE_LOGGING === 'true';
 const logDir = process.env.LOG_DIR || path.join(process.cwd(), 'logs');
 /**
- * 如果環境參數的ENABLE_FILE_LOGGING是false，則不會寫入日誌到檔案
- * 如果有指定LOG_DIR，則會寫入日誌到指定的目錄
- * 如果沒有指定LOG_DIR，則會寫入日誌到logs目錄
- * 如果沒有指定LOG_LEVEL，則會使用info等級
- * 如果沒有指定NODE_ENV，則會使用development等級
+ * If ENABLE_FILE_LOGGING is false, logs will not be written to files.
+ * If LOG_DIR is specified, logs will be written to the specified directory.
+ * If LOG_DIR is not specified, logs will be written to the logs directory.
+ * If LOG_LEVEL is not specified, the info level will be used.
+ * If NODE_ENV is not specified, the development environment will be used.
  */
 
-// 創建 logger 實例
+// Create logger instance
 export const log = winston.createLogger({
   level: logLevel || 'info',
   format: logFormat,
-  transports: []  // 不添加任何控制台輸出
+  transports: []  // No console output
 });
 
-// 如果啟用檔案日誌，添加檔案 transports
+// If file logging is enabled, add file transports
 if (enableFileLogging) {
   
-  // 添加綜合日誌檔案
+  // Add combined log file
   log.add(
     new winston.transports.File({
       filename: path.join(logDir, 'mantis-mcp-server-combined.log'),
@@ -37,7 +37,7 @@ if (enableFileLogging) {
     })
   );
 
-  // 添加錯誤日誌檔案 - 只處理錯誤級別的日誌
+  // Add error log file - only handles error-level logs
   log.add(
     new winston.transports.File({
       filename: path.join(logDir, 'mantis-mcp-server-error.log'),


### PR DESCRIPTION
## Summary
- Add `sort` and `dir` parameters to `get_issues` for ordering results (e.g. sort by `id` ASC to get oldest issues first)
- Add new `change_issue_status` tool that combines a status transition with an optional note in a single operation — useful when Mantis requires a note on status change

## Changes
- `src/services/mantisApi.ts`: Add `sort`/`dir` to `IssueSearchParams` and query builder; add `changeIssueStatus()` method
- `src/server.ts`: Expose `sort`/`dir` on `get_issues`; register new `change_issue_status` MCP tool

## Test plan
- [ ] Call `get_issues` with `sort: "id", dir: "ASC"` and verify oldest issues come first
- [ ] Call `change_issue_status` with a note and verify both the note and status change are applied
- [ ] Call `change_issue_status` without a note and verify only the status changes